### PR TITLE
Fixed pip install issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,8 @@
-MVtest GWAS Analysis
+GWAS Library
 ====================
 
-MVtest is an analysis tool that can be run on many common file formats using
-syntax similar to programs you've probably already used. Instructions for
-installation can be found below.
+libGWAS is a set of libraries used by various applications for parsing 
+and manipulating GWAS datasets. 
 
 Installation
 ============

--- a/libgwas/__init__.py
+++ b/libgwas/__init__.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from sys import stderr
 import numpy
-from . import exceptions
 import datetime
 import math
 


### PR DESCRIPTION
An outdated import was causing pip trouble installing directly from github. 